### PR TITLE
PAAS-395 remove 10s query_timeout (default is 1 day)

### DIFF
--- a/configs/proxysql.cnf
+++ b/configs/proxysql.cnf
@@ -12,7 +12,6 @@ mysql_variables=
     threads=2
     max_connections=2048
     default_query_delay=0
-    default_query_timeout=10000
     poll_timeout=2000
     interfaces="0.0.0.0:3306"
     default_schema="information_schema"


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-395

Short description: remove query timeout at 10s (now default value, so 1 day)
